### PR TITLE
Remove redundant build flags

### DIFF
--- a/net.sourceforge.Teo.json
+++ b/net.sourceforge.Teo.json
@@ -13,8 +13,6 @@
         "--device=all"
     ],
     "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags" : "-O2 -g",
         "env" : {
             "DEBUGMODE": "1"
         }


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.